### PR TITLE
Add Ψ_AGI score calculation and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/psi_agi.py
+++ b/psi_agi.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from typing import Optional
+
+
+def compute_psi_agi(price_df: pd.DataFrame, prediction_df: pd.DataFrame, *, window: int = 10) -> pd.DataFrame:
+    """Compute Ψ_AGI scores for predicted prices.
+
+    Parameters
+    ----------
+    price_df : pd.DataFrame
+        DataFrame containing at least ``Normalized`` and ``Quantum_Output`` columns.
+    prediction_df : pd.DataFrame
+        DataFrame containing ``Predicted_Normalized_Price`` column.
+    window : int, optional
+        Window size used for volatility estimation, by default 10.
+
+    Returns
+    -------
+    pd.DataFrame
+        ``prediction_df`` with an added ``Ψ_AGI_Score`` column.
+    """
+
+    if "Normalized" not in price_df or "Quantum_Output" not in price_df:
+        raise KeyError("price_df must contain 'Normalized' and 'Quantum_Output' columns")
+    if "Predicted_Normalized_Price" not in prediction_df:
+        raise KeyError("prediction_df must contain 'Predicted_Normalized_Price' column")
+
+    rolling_volatility = price_df["Normalized"].rolling(window=window).std().fillna(method="bfill")
+
+    latest_quantum = price_df["Quantum_Output"].iloc[-1]
+    latest_volatility = rolling_volatility.iloc[-1]
+
+    predicted_prices = prediction_df["Predicted_Normalized_Price"].values
+
+    psi_agi_scores = [
+        (latest_quantum * pred) / (1 + latest_volatility)
+        for pred in predicted_prices
+    ]
+
+    prediction_df = prediction_df.copy()
+    prediction_df["Ψ_AGI_Score"] = psi_agi_scores
+    return prediction_df
+
+
+__all__ = ["compute_psi_agi"]
+

--- a/psi_agi.py
+++ b/psi_agi.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from typing import Optional
 
 
 def compute_psi_agi(price_df: pd.DataFrame, prediction_df: pd.DataFrame, *, window: int = 10) -> pd.DataFrame:
@@ -25,7 +24,7 @@ def compute_psi_agi(price_df: pd.DataFrame, prediction_df: pd.DataFrame, *, wind
     if "Predicted_Normalized_Price" not in prediction_df:
         raise KeyError("prediction_df must contain 'Predicted_Normalized_Price' column")
 
-    rolling_volatility = price_df["Normalized"].rolling(window=window).std().fillna(method="bfill")
+    rolling_volatility = price_df["Normalized"].rolling(window=window).std().bfill()
 
     latest_quantum = price_df["Quantum_Output"].iloc[-1]
     latest_volatility = rolling_volatility.iloc[-1]

--- a/tests/test_psi_agi.py
+++ b/tests/test_psi_agi.py
@@ -17,7 +17,7 @@ def test_compute_psi_agi_basic():
     result = compute_psi_agi(price_df, prediction_df, window=3)
 
     assert "Ψ_AGI_Score" in result.columns
-    expected_vol = price_df["Normalized"].rolling(window=3).std().fillna(method="bfill").iloc[-1]
+    expected_vol = price_df["Normalized"].rolling(window=3).std().bfill().iloc[-1]
     latest_quantum = price_df["Quantum_Output"].iloc[-1]
     expected_scores = [
         (latest_quantum * pred) / (1 + expected_vol)

--- a/tests/test_psi_agi.py
+++ b/tests/test_psi_agi.py
@@ -1,0 +1,34 @@
+import pytest
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+from psi_agi import compute_psi_agi
+
+
+def test_compute_psi_agi_basic():
+    price_df = pd.DataFrame({
+        "Normalized": [1.0, 1.2, 1.1, 1.3, 1.4, 1.5, 1.3, 1.2, 1.1, 1.0],
+        "Quantum_Output": [0.5] * 10,
+    })
+    prediction_df = pd.DataFrame({
+        "Predicted_Normalized_Price": [1.1, 0.9, 1.0]
+    })
+
+    result = compute_psi_agi(price_df, prediction_df, window=3)
+
+    assert "Ψ_AGI_Score" in result.columns
+    expected_vol = price_df["Normalized"].rolling(window=3).std().fillna(method="bfill").iloc[-1]
+    latest_quantum = price_df["Quantum_Output"].iloc[-1]
+    expected_scores = [
+        (latest_quantum * pred) / (1 + expected_vol)
+        for pred in prediction_df["Predicted_Normalized_Price"].values
+    ]
+    assert result["Ψ_AGI_Score"].tolist() == pytest.approx(expected_scores)
+
+
+def test_missing_columns():
+    price_df = pd.DataFrame({"Normalized": [1], "Quantum_Output": [0.5]})
+    pred_df = pd.DataFrame({"Other": [1]})
+    with pytest.raises(KeyError):
+        compute_psi_agi(price_df, pred_df)
+


### PR DESCRIPTION
## Summary
- implement `compute_psi_agi` for scoring predicted prices
- add unit tests covering normal operation and missing columns
- ignore runtime caches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cd8dee34832abf12d7541d0d8704