### PR TITLE
Add FastAPI service for curvature metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .pytest_cache/
+data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # Theinxh
+
+This repository includes an example Streamlit dashboard for exploring curvature
+simulations and simple multi‑agent interactions powered by LangChain and
+Hugging Face models. Temporal curvature ``Λ`` is computed using the TICE
+equation and a lightweight multi‑agent extension. The dashboard can simulate
+randomised agents or derive curvature directly from MNIST digit samples to
+illustrate behaviour on real data.
+
+Run the demo with:
+
+```bash
+pip install streamlit langchain langchain-experimental huggingface_hub
+streamlit run qbond_curvature_dashboard.py
+```
+
+Curvature utilities are available in ``tice.py`` and ``mnist_curvature.py`` for
+reuse in other projects.
+
+## FastAPI Microservice
+
+Metrics can also be accessed programmatically via a FastAPI service exposing
+three endpoints:
+
+- ``POST /simulate/curvature`` – generate random multi‑agent simulations and
+  return ``Λ`` and curve index ``C`` values.
+- ``POST /compute/xi_chi`` – compute the ``Ξχ`` negentropy metric for a
+  probability distribution.
+- ``POST /forecast/scg`` – forecast Symbolic Curvature Gain ``SCG`` from a
+  series of curvature scores.
+
+Start the service with:
+
+```bash
+pip install fastapi uvicorn
+uvicorn fastapi_service:app --reload
+```
+
+### Plugin Connectors
+
+``connectors.py`` contains lightweight helper functions for integrating the
+service with external frameworks:
+
+- LangChain tools can invoke curvature simulations directly.
+- Groq API style callables for accelerator driven workloads.
+- Hugging Face Spaces demo hooks for community apps.
+- AutoGPT plugin helpers to monitor ``SCG`` during swarms.
+
+These connectors demonstrate how the microservice can plug into different AI
+stacks.

--- a/connectors.py
+++ b/connectors.py
@@ -1,0 +1,55 @@
+"""Integration helpers for external AI frameworks."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import requests
+
+
+def langchain_tool(api_url: str) -> Any:  # pragma: no cover - optional dependency
+    """Return a LangChain ``Tool`` that calls the curvature simulation API."""
+    try:
+        from langchain.tools import Tool
+    except Exception as exc:  # pragma: no cover - langchain may be absent
+        raise ImportError("langchain must be installed to use this tool") from exc
+
+    def _run(_: str) -> str:
+        resp = requests.post(f"{api_url}/simulate/curvature", json={})
+        return resp.text
+
+    return Tool(name="simulate_curvature", func=_run, description="Simulate curvature via TICE service")
+
+
+def groq_connector(api_url: str) -> Callable[[], dict]:
+    """Return a callable that fetches curvature metrics using the Groq API style."""
+    def _call() -> dict:
+        resp = requests.post(f"{api_url}/simulate/curvature", json={})
+        return resp.json()
+
+    return _call
+
+
+def huggingface_space_connector(api_url: str) -> Callable[[], dict]:
+    """Simple callable for Hugging Face Spaces demos."""
+    def _call() -> dict:
+        return requests.post(f"{api_url}/simulate/curvature", json={}).json()
+
+    return _call
+
+
+def autogpt_plugin(api_url: str) -> Callable[[], dict]:
+    """Return a function suitable for AutoGPT plugins to monitor SCG."""
+    def _call() -> dict:
+        data = {"lambdas": [0.1, 0.2], "dt": 1.0}
+        resp = requests.post(f"{api_url}/forecast/scg", json=data)
+        return resp.json()
+
+    return _call
+
+
+__all__ = [
+    "langchain_tool",
+    "groq_connector",
+    "huggingface_space_connector",
+    "autogpt_plugin",
+]

--- a/fastapi_service.py
+++ b/fastapi_service.py
@@ -1,0 +1,67 @@
+"""FastAPI microservice exposing TICE curvature metrics."""
+from __future__ import annotations
+
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from tice import multi_agent_curvature
+from metrics import curve_index, compute_xi_chi, forecast_scg
+
+
+app = FastAPI(title="TICE Curvature Service")
+
+
+class CurvatureRequest(BaseModel):
+    agents: int = 3
+    steps: int = 3
+
+
+@app.post("/simulate/curvature")
+def simulate_curvature(req: CurvatureRequest):
+    agents = req.agents
+    steps = req.steps
+    delta_psi_sq = np.abs(np.random.normal(0.5, 0.2, size=(agents, steps)))
+    tau = np.abs(np.random.normal(1.0, 0.1, size=(agents, steps)))
+    eta = np.abs(np.random.normal(0.5, 0.1, size=agents))
+    eta_dot = np.random.normal(0.0, 0.05, size=agents)
+    phi = np.random.rand(agents, agents)
+    phi = (phi + phi.T) / 2
+    np.fill_diagonal(phi, 0.0)
+    coupling = np.ones((agents, agents)) - np.eye(agents)
+
+    lam = multi_agent_curvature(
+        delta_psi_sq,
+        tau,
+        eta=eta,
+        gamma=0.5,
+        eta_dot=eta_dot,
+        phi=phi,
+        coupling=coupling,
+    )
+    weights = np.ones(agents) / agents
+    c_val = curve_index(phi, weights)
+    return {"lambda": lam, "curve_index": c_val}
+
+
+class XiChiRequest(BaseModel):
+    probabilities: list[float]
+
+
+@app.post("/compute/xi_chi")
+def api_compute_xi_chi(req: XiChiRequest):
+    return {"xi_chi": compute_xi_chi(req.probabilities)}
+
+
+class ScgRequest(BaseModel):
+    lambdas: list[float]
+    dt: float = 1.0
+
+
+@app.post("/forecast/scg")
+def api_forecast_scg(req: ScgRequest):
+    try:
+        scg_val = forecast_scg(req.lambdas, dt=req.dt)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"scg": scg_val}

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,53 @@
+"""Auxiliary metrics for the TICE curvature system."""
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+def curve_index(trust: np.ndarray, weights: Sequence[float]) -> float:
+    """Compute a simple Curve Index ``C`` from a trust graph.
+
+    Parameters
+    ----------
+    trust : np.ndarray
+        Symmetric trust adjacency matrix ``Phi`` with values in ``[0, 1]``.
+    weights : Sequence[float]
+        Importance weights ``w_i`` for each agent.
+
+    Returns
+    -------
+    float
+        Aggregate curve index.
+    """
+    trust = np.asarray(trust, dtype=float)
+    weights = np.asarray(weights, dtype=float)
+    degrees = trust.sum(axis=1)
+    n = trust.shape[0]
+    c_val = 0.0
+    for i in range(n):
+        for j in range(i + 1, n):
+            if trust[i, j] > 0:
+                g = 4 - degrees[i] - degrees[j]
+                w = 0.5 * (weights[i] + weights[j])
+                c_val += w * g * trust[i, j]
+    return float(c_val)
+
+
+def compute_xi_chi(probabilities: Sequence[float]) -> float:
+    """Compute ``XiChi`` negentropy metric for a probability distribution."""
+    p = np.asarray(probabilities, dtype=float)
+    p = p / (p.sum() + 1e-12)
+    return float(-np.sum(p * np.log2(p + 1e-12)))
+
+
+def forecast_scg(lambdas: Sequence[float], dt: float = 1.0) -> float:
+    """Forecast Symbolic Curvature Gain (SCG) from a series of ``Lambda`` values."""
+    lam = np.asarray(lambdas, dtype=float)
+    if len(lam) < 2:
+        raise ValueError("Need at least two lambda values")
+    return float((lam[-1] - lam[0]) / (dt * (len(lam) - 1)))
+
+
+__all__ = ["curve_index", "compute_xi_chi", "forecast_scg"]

--- a/mnist_curvature.py
+++ b/mnist_curvature.py
@@ -1,0 +1,120 @@
+"""MNIST-driven multi-agent curvature utilities."""
+from __future__ import annotations
+
+import gzip
+import os
+import urllib.request
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from tice import multi_agent_curvature
+
+MNIST_URLS = {
+    "images": "https://storage.googleapis.com/cvdf-datasets/mnist/train-images-idx3-ubyte.gz",
+    "labels": "https://storage.googleapis.com/cvdf-datasets/mnist/train-labels-idx1-ubyte.gz",
+}
+
+
+def _download_mnist(data_dir: Path) -> Tuple[Path, Path]:
+    """Download MNIST train set if not already present.
+
+    Parameters
+    ----------
+    data_dir : Path
+        Directory to store dataset files.
+
+    Returns
+    -------
+    Tuple[Path, Path]
+        Paths to the image and label files.
+    """
+    data_dir.mkdir(parents=True, exist_ok=True)
+    image_path = data_dir / "train-images-idx3-ubyte.gz"
+    label_path = data_dir / "train-labels-idx1-ubyte.gz"
+    if not image_path.exists():
+        urllib.request.urlretrieve(MNIST_URLS["images"], image_path)
+    if not label_path.exists():
+        urllib.request.urlretrieve(MNIST_URLS["labels"], label_path)
+    return image_path, label_path
+
+
+def load_mnist(data_dir: str | os.PathLike[str] = "data") -> Tuple[np.ndarray, np.ndarray]:
+    """Load MNIST images and labels as ``float`` arrays in ``[0, 1]``.
+
+    The dataset is downloaded on first use.
+    """
+    img_path, lbl_path = _download_mnist(Path(data_dir))
+    with gzip.open(img_path, "rb") as f:
+        images = np.frombuffer(f.read(), np.uint8, offset=16)
+    images = images.reshape(-1, 28 * 28).astype(float) / 255.0
+    with gzip.open(lbl_path, "rb") as f:
+        labels = np.frombuffer(f.read(), np.uint8, offset=8)
+    return images, labels
+
+
+def mnist_multi_agent_lambda(
+    images: np.ndarray,
+    labels: np.ndarray,
+    *,
+    agents: int = 3,
+    samples: int = 2,
+) -> float:
+    """Compute a multi-agent curvature score from MNIST samples.
+
+    Parameters
+    ----------
+    images : np.ndarray
+        MNIST images flattened to vectors in ``[0, 1]``.
+    labels : np.ndarray
+        Corresponding digit labels.
+    agents : int, optional
+        Number of digit agents to sample, by default ``3``.
+    samples : int, optional
+        Number of successive samples per agent, by default ``2``.
+    """
+    digits = np.random.choice(np.arange(10), size=agents, replace=False)
+    delta_list = []
+    tau_list = []
+    eta_list = []
+    eta_dot_list = []
+    mean_states = []
+
+    for d in digits:
+        idx = np.where(labels == d)[0]
+        chosen = np.random.choice(idx, size=samples + 1, replace=False)
+        imgs = images[chosen]
+        state_changes = np.diff(imgs, axis=0)
+        dpsi = np.sum(state_changes ** 2, axis=1)
+        delta_list.append(dpsi)
+        tau_list.append(np.ones_like(dpsi))
+
+        # Entropy of pixel distribution as eta
+        hist1 = np.histogram(imgs[0], bins=256, range=(0.0, 1.0), density=True)[0] + 1e-8
+        hist2 = np.histogram(imgs[1], bins=256, range=(0.0, 1.0), density=True)[0] + 1e-8
+        entropy1 = -np.sum(hist1 * np.log2(hist1))
+        entropy2 = -np.sum(hist2 * np.log2(hist2))
+        eta_list.append(float(entropy1))
+        eta_dot_list.append(float(entropy2 - entropy1))
+        mean_states.append(imgs.mean(axis=0))
+
+    mean_states_arr = np.asarray(mean_states)
+    norms = np.linalg.norm(mean_states_arr, axis=1, keepdims=True) + 1e-8
+    normed = mean_states_arr / norms
+    phi = normed @ normed.T
+    np.fill_diagonal(phi, 0.0)
+    coupling = np.ones((agents, agents)) - np.eye(agents)
+
+    return multi_agent_curvature(
+        delta_list,
+        tau_list,
+        eta=eta_list,
+        gamma=0.5,
+        eta_dot=eta_dot_list,
+        phi=phi,
+        coupling=coupling,
+    )
+
+
+__all__ = ["load_mnist", "mnist_multi_agent_lambda"]

--- a/qbond_curvature_dashboard.py
+++ b/qbond_curvature_dashboard.py
@@ -1,0 +1,84 @@
+import numpy as np
+import streamlit as st
+from langchain.llms import HuggingFaceHub
+from langchain.schema import AIMessage, HumanMessage, SystemMessage
+
+try:  # pragma: no cover - optional dependency
+    from langchain_experimental.autonomous_agents import AutoGPT
+except Exception:  # pragma: no cover - optional dependency
+    AutoGPT = None
+
+from tice import multi_agent_curvature
+from mnist_curvature import load_mnist, mnist_multi_agent_lambda
+
+
+st.title("Q-BOND Curvature Dashboard")
+st.subheader("Live Curvature Simulation")
+
+data_source = st.selectbox("Data Source", ["Random", "MNIST"])
+rounds = st.slider("Rounds", 1, 10, 3)
+agents = st.slider("Agents", 2, 10, 2)
+
+if data_source == "MNIST":
+    images, labels = load_mnist()
+
+lambdas = []
+for _ in range(rounds):
+    if data_source == "Random":
+        delta_psi_sq = np.abs(np.random.normal(0.5, 0.2, size=(agents, 3)))
+        tau = np.abs(np.random.normal(1.0, 0.1, size=(agents, 3)))
+        eta = np.abs(np.random.normal(0.5, 0.1, size=agents))
+        eta_dot = np.random.normal(0.0, 0.05, size=agents)
+        phi = np.random.rand(agents, agents)
+        phi = (phi + phi.T) / 2
+        np.fill_diagonal(phi, 0.0)
+        coupling = np.ones((agents, agents)) - np.eye(agents)
+        lam = multi_agent_curvature(
+            delta_psi_sq,
+            tau,
+            eta=eta,
+            gamma=0.5,
+            eta_dot=eta_dot,
+            phi=phi,
+            coupling=coupling,
+        )
+    else:
+        lam = mnist_multi_agent_lambda(images, labels, agents=agents, samples=2)
+    lambdas.append(lam)
+
+st.line_chart(lambdas)
+st.metric("Final Λ_multi", f"{lambdas[-1]:.4f}")
+st.metric("Symbolic Curvature Gain (SCG)", f"{(lambdas[-1] - lambdas[0]):.4f}")
+
+st.header("LangChain Multi-Agent Playground")
+
+if st.button("Chat Between Agents"):
+    llm = HuggingFaceHub(repo_id="gpt2", model_kwargs={"temperature": 0.7})
+    messages = [
+        SystemMessage(content="You are Agent Alpha analyzing curvature."),
+        HumanMessage(content="Discuss the curvature implications on λ."),
+    ]
+    alpha_reply = llm(messages)
+    st.write("Agent Alpha:", alpha_reply.content)
+
+    messages.extend(
+        [
+            AIMessage(content=alpha_reply.content),
+            SystemMessage(content="You are Agent Beta responding to Agent Alpha."),
+        ]
+    )
+    beta_reply = llm(messages)
+    st.write("Agent Beta:", beta_reply.content)
+
+if AutoGPT and st.button("AutoGPT Planning"):
+    llm = HuggingFaceHub(repo_id="gpt2", model_kwargs={"temperature": 0})
+    agent = AutoGPT.from_llm_and_tools(
+        ai_name="CurvaturePlanner",
+        ai_role="Plan curvature experiments",
+        tools=[],
+        llm=llm,
+        human_in_the_loop=False,
+    )
+    plan = agent.run(["Propose a new curvature experiment with λ"])
+    st.write(plan)
+

--- a/tests/test_mnist_curvature.py
+++ b/tests/test_mnist_curvature.py
@@ -1,0 +1,14 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mnist_curvature import load_mnist, mnist_multi_agent_lambda
+
+
+def test_mnist_multi_agent_lambda():
+    images, labels = load_mnist()
+    lam = mnist_multi_agent_lambda(images, labels, agents=3, samples=2)
+    assert isinstance(lam, float)
+    assert np.isfinite(lam)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,33 @@
+import math
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fastapi_service import app
+
+
+client = TestClient(app)
+
+
+def test_simulate_curvature_endpoint():
+    resp = client.post("/simulate/curvature", json={"agents": 2, "steps": 2})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "lambda" in data and "curve_index" in data
+    assert isinstance(data["lambda"], float)
+
+
+def test_compute_xi_chi_endpoint():
+    resp = client.post("/compute/xi_chi", json={"probabilities": [0.2, 0.8]})
+    assert resp.status_code == 200
+    xi_chi = resp.json()["xi_chi"]
+    expected = -0.2 * math.log2(0.2) - 0.8 * math.log2(0.8)
+    assert xi_chi == pytest.approx(expected)
+
+
+def test_forecast_scg_endpoint():
+    resp = client.post("/forecast/scg", json={"lambdas": [0.1, 0.3, 0.5], "dt": 1.0})
+    assert resp.status_code == 200
+    scg = resp.json()["scg"]
+    expected = (0.5 - 0.1) / 2
+    assert scg == pytest.approx(expected)

--- a/tests/test_tice.py
+++ b/tests/test_tice.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from tice import multi_agent_curvature, temporal_curvature
+
+
+def test_temporal_curvature_basic():
+    delta_psi_sq = [1.0, 2.0]
+    tau = [1.0, 0.5]
+    result = temporal_curvature(delta_psi_sq, tau, eta=1.0, gamma=0.5, eta_dot=0.1)
+    expected = (1.0 * 1.0 + 2.0 * 0.5) / (1.0 + 0.5 * 0.1)
+    assert result == pytest.approx(expected)
+
+
+def test_multi_agent_curvature_pair():
+    delta_psi_sq = [[1.0], [4.0]]
+    tau = [[1.0], [1.0]]
+    eta = [1.0, 1.0]
+    eta_dot = [0.1, 0.2]
+    phi = np.array([[0.0, 0.5], [0.5, 0.0]])
+    coupling = np.array([[0.0, 1.0], [1.0, 0.0]])
+    lam = multi_agent_curvature(
+        delta_psi_sq,
+        tau,
+        eta=eta,
+        gamma=0.5,
+        eta_dot=eta_dot,
+        phi=phi,
+        coupling=coupling,
+    )
+    lambda1 = (1.0 * 1.0) / (1.0 + 0.5 * 0.1)
+    lambda2 = (4.0 * 1.0) / (1.0 + 0.5 * 0.2)
+    expected = 0.5 * 0.5 * (lambda1 + lambda2)  # phi * coupling * mean
+    assert lam == pytest.approx(expected)

--- a/tice.py
+++ b/tice.py
@@ -1,0 +1,110 @@
+"""TICE curvature computation utilities."""
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+def temporal_curvature(
+    delta_psi_sq: Sequence[float],
+    tau: Sequence[float],
+    *,
+    eta: float,
+    gamma: float,
+    eta_dot: float,
+    epsilon: float = 1e-6,
+) -> float:
+    """Compute temporal curvature :math:`\Lambda(t)` for a single agent.
+
+    Parameters
+    ----------
+    delta_psi_sq : Sequence[float]
+        Squared changes in symbolic state :math:`\Delta \psi^2`.
+    tau : Sequence[float]
+        Memory persistence values :math:`\tau` for each state change.
+    eta : float
+        Entropy pressure :math:`\eta`.
+    gamma : float
+        Damping constant :math:`\gamma`.
+    eta_dot : float
+        Rate of change of entropy :math:`\frac{d\eta}{dt}`.
+    epsilon : float, optional
+        Stabiliser to prevent division by zero, by default ``1e-6``.
+
+    Returns
+    -------
+    float
+        Temporal curvature score.
+    """
+
+    delta_psi_sq_arr = np.asarray(delta_psi_sq, dtype=float)
+    tau_arr = np.asarray(tau, dtype=float)
+    numerator = np.sum(delta_psi_sq_arr * tau_arr)
+    denominator = eta + gamma * abs(eta_dot) + epsilon
+    return float(numerator / denominator)
+
+
+def multi_agent_curvature(
+    delta_psi_sq: Sequence[Sequence[float]],
+    tau: Sequence[Sequence[float]],
+    *,
+    eta: Sequence[float],
+    gamma: float,
+    eta_dot: Sequence[float],
+    phi: np.ndarray,
+    coupling: np.ndarray,
+    epsilon: float = 1e-6,
+) -> float:
+    """Compute multi-agent curvature :math:`\Lambda_{multi}`.
+
+    Each agent ``i`` contributes a temporal curvature ``lambda_i``. The
+    pairwise trust matrix ``phi`` and temporal coupling ``coupling`` weight the
+    influence between agents ``i`` and ``j``.
+
+    Parameters
+    ----------
+    delta_psi_sq : Sequence[Sequence[float]]
+        Squared state changes for each agent.
+    tau : Sequence[Sequence[float]]
+        Memory persistence values per agent.
+    eta : Sequence[float]
+        Entropy pressure for each agent.
+    gamma : float
+        Damping constant shared across agents.
+    eta_dot : Sequence[float]
+        Entropy change rate for each agent.
+    phi : np.ndarray
+        Trust correlation matrix ``Phi`` with values in ``[0, 1]``.
+    coupling : np.ndarray
+        Temporal coupling kernel ``K`` with values in ``[0, 1]``.
+    epsilon : float, optional
+        Stabiliser to prevent division by zero, by default ``1e-6``.
+
+    Returns
+    -------
+    float
+        Multi-agent curvature score.
+    """
+
+    n_agents = len(delta_psi_sq)
+    if phi.shape != (n_agents, n_agents) or coupling.shape != (n_agents, n_agents):
+        raise ValueError("phi and coupling must be square matrices matching agent count")
+
+    lambdas = [
+        temporal_curvature(dps, t, eta=e, gamma=gamma, eta_dot=ed, epsilon=epsilon)
+        for dps, t, e, ed in zip(delta_psi_sq, tau, eta, eta_dot)
+    ]
+    lambdas_arr = np.asarray(lambdas)
+
+    pair_sum = 0.0
+    count = 0
+    for i in range(n_agents):
+        for j in range(i + 1, n_agents):
+            weight = phi[i, j] * coupling[i, j]
+            pair_sum += weight * (lambdas_arr[i] + lambdas_arr[j]) / 2
+            count += 1
+    return float(pair_sum / max(count, 1))
+
+
+__all__ = ["temporal_curvature", "multi_agent_curvature"]


### PR DESCRIPTION
## Summary
- add `metrics` module with Curve Index, XiChi, and SCG calculations
- expose curvature metrics via FastAPI endpoints and provide plugin connectors
- document the service and plugin architecture in README

## Testing
- `python -m pip install fastapi uvicorn httpx`
- `python -m pip install numpy pandas`
- `pytest -q`
- `python fastapi_service` sample requests

------
https://chatgpt.com/codex/tasks/task_e_689195d054b8832aa8d53f991e83a4e8